### PR TITLE
Context and client.

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -1,12 +1,21 @@
 package nzbget
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Version returns the NZBGet Version.
 // https://nzbget.net/api/version
 func (n *NZBGet) Version() (string, int, error) {
+	return n.VersionWithContext(context.Background())
+}
+
+// VersionWithContext returns the NZBGet Version.
+// https://nzbget.net/api/version
+func (n *NZBGet) VersionWithContext(ctx context.Context) (string, int, error) {
 	var output string
-	size, err := n.GetInto("version", &output)
+	size, err := n.GetInto(ctx, "version", &output)
 
 	return output, size, err
 }
@@ -15,8 +24,15 @@ func (n *NZBGet) Version() (string, int, error) {
 // https://nzbget.net/api/listfiles
 // nzbID is the NZBID of the group to be returned. Use 0 for all file groups.
 func (n *NZBGet) ListFiles(nzbID int64) (*File, int, error) {
+	return n.ListFilesWithContext(context.Background(), nzbID)
+}
+
+// ListFilesWithContext returns the NZBGet Files for a download.
+// https://nzbget.net/api/listfiles
+// nzbID is the NZBID of the group to be returned. Use 0 for all file groups.
+func (n *NZBGet) ListFilesWithContext(ctx context.Context, nzbID int64) (*File, int, error) {
 	var output File
-	size, err := n.GetInto("listfiles", &output, 0, 0, nzbID)
+	size, err := n.GetInto(ctx, "listfiles", &output, 0, 0, nzbID)
 
 	return &output, size, err
 }
@@ -24,8 +40,14 @@ func (n *NZBGet) ListFiles(nzbID int64) (*File, int, error) {
 // Status returns the NZBGet Status.
 // https://nzbget.net/api/status
 func (n *NZBGet) Status() (*Status, int, error) {
+	return n.StatusWithContext(context.Background())
+}
+
+// StatusWithContext returns the NZBGet Status.
+// https://nzbget.net/api/status
+func (n *NZBGet) StatusWithContext(ctx context.Context) (*Status, int, error) {
 	var output Status
-	size, err := n.GetInto("status", &output)
+	size, err := n.GetInto(ctx, "status", &output)
 
 	return &output, size, err
 }
@@ -33,8 +55,14 @@ func (n *NZBGet) Status() (*Status, int, error) {
 // History returns the NZBGet Download History.
 // https://nzbget.net/api/history
 func (n *NZBGet) History(hidden bool) ([]*History, int, error) {
+	return n.HistoryWithContext(context.Background(), hidden)
+}
+
+// HistoryWithContext returns the NZBGet Download History.
+// https://nzbget.net/api/history
+func (n *NZBGet) HistoryWithContext(ctx context.Context, hidden bool) ([]*History, int, error) {
 	var output []*History
-	size, err := n.GetInto("history", &output, hidden)
+	size, err := n.GetInto(ctx, "history", &output, hidden)
 
 	return output, size, err
 }
@@ -42,8 +70,14 @@ func (n *NZBGet) History(hidden bool) ([]*History, int, error) {
 // ListGroups returns the NZBGet Download list.
 // https://nzbget.net/api/listgroups
 func (n *NZBGet) ListGroups() ([]*Group, int, error) {
+	return n.ListGroupsWithContext(context.Background())
+}
+
+// ListGroupsWithContext returns the NZBGet Download list.
+// https://nzbget.net/api/listgroups
+func (n *NZBGet) ListGroupsWithContext(ctx context.Context) ([]*Group, int, error) {
 	var output []*Group
-	size, err := n.GetInto("listgroups", &output, 0)
+	size, err := n.GetInto(ctx, "listgroups", &output, 0)
 
 	return output, size, err
 }
@@ -52,18 +86,32 @@ func (n *NZBGet) ListGroups() ([]*Group, int, error) {
 // NOTE: only one parameter - either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/log
 func (n *NZBGet) Log(startID, limit int64) ([]*LogEntry, int, error) {
+	return n.LogWithContext(context.Background(), startID, limit)
+}
+
+// LogWithContext returns the NZBGet Logs.
+// NOTE: only one parameter - either startID or limit - can be specified. The other parameter must be 0.
+// https://nzbget.net/api/log
+func (n *NZBGet) LogWithContext(ctx context.Context, startID, limit int64) ([]*LogEntry, int, error) {
 	var output []*LogEntry
-	size, err := n.GetInto("log", &output, startID, limit)
+	size, err := n.GetInto(ctx, "log", &output, startID, limit)
 
 	return output, size, err
 }
 
-// LLoadLogog returns the NZBGet log for a specific download.
+// LoadLog returns the NZBGet log for a specific download.
 // NOTE: only one of either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/loadlog
 func (n *NZBGet) LoadLog(nzbID, startID, limit int64) ([]*LogEntry, int, error) {
+	return n.LoadLogWithContext(context.Background(), nzbID, startID, limit)
+}
+
+// LoadLogWithContext returns the NZBGet log for a specific download.
+// NOTE: only one of either startID or limit - can be specified. The other parameter must be 0.
+// https://nzbget.net/api/loadlog
+func (n *NZBGet) LoadLogWithContext(ctx context.Context, nzbID, startID, limit int64) ([]*LogEntry, int, error) {
 	var output []*LogEntry
-	size, err := n.GetInto("loadlog", &output, nzbID, startID, limit)
+	size, err := n.GetInto(ctx, "loadlog", &output, nzbID, startID, limit)
 
 	return output, size, err
 }
@@ -71,8 +119,14 @@ func (n *NZBGet) LoadLog(nzbID, startID, limit int64) ([]*LogEntry, int, error) 
 // Config returns the loaded and active NZBGet configuration parameters.
 // https://nzbget.net/api/config
 func (n *NZBGet) Config() ([]*Parameter, int, error) {
+	return n.ConfigWithContext(context.Background())
+}
+
+// ConfigWithContext returns the loaded and active NZBGet configuration parameters.
+// https://nzbget.net/api/config
+func (n *NZBGet) ConfigWithContext(ctx context.Context) ([]*Parameter, int, error) {
 	var output []*Parameter
-	size, err := n.GetInto("config", &output)
+	size, err := n.GetInto(ctx, "config", &output)
 
 	return output, size, err
 }
@@ -80,8 +134,14 @@ func (n *NZBGet) Config() ([]*Parameter, int, error) {
 // LoadConfig returns the configuration from disk.
 // https://nzbget.net/api/loadconfig
 func (n *NZBGet) LoadConfig() ([]*Parameter, int, error) {
+	return n.LoadConfigWithContext(context.Background())
+}
+
+// LoadConfigWithContext returns the configuration from disk.
+// https://nzbget.net/api/loadconfig
+func (n *NZBGet) LoadConfigWithContext(ctx context.Context) ([]*Parameter, int, error) {
 	var output []*Parameter
-	size, err := n.GetInto("loadconfig", &output)
+	size, err := n.GetInto(ctx, "loadconfig", &output)
 
 	return output, size, err
 }
@@ -89,8 +149,14 @@ func (n *NZBGet) LoadConfig() ([]*Parameter, int, error) {
 // SaveConfig writes new configuration parameters to disk.
 // https://nzbget.net/api/saveconfig
 func (n *NZBGet) SaveConfig(configs []*Parameter) (bool, int, error) {
+	return n.SaveConfigWithContext(context.Background(), configs)
+}
+
+// SaveConfigWithContext writes new configuration parameters to disk.
+// https://nzbget.net/api/saveconfig
+func (n *NZBGet) SaveConfigWithContext(ctx context.Context, configs []*Parameter) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("saveconfig", &output, configs)
+	size, err := n.GetInto(ctx, "saveconfig", &output, configs)
 
 	return output, size, err
 }
@@ -98,8 +164,14 @@ func (n *NZBGet) SaveConfig(configs []*Parameter) (bool, int, error) {
 // Shutdown makes NZBGet exit.
 // https://nzbget.net/api/shutdown
 func (n *NZBGet) Shutdown() (bool, int, error) {
+	return n.ShutdownWithContext(context.Background())
+}
+
+// ShutdownWithContext makes NZBGet exit.
+// https://nzbget.net/api/shutdown
+func (n *NZBGet) ShutdownWithContext(ctx context.Context) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("shutdown", &output)
+	size, err := n.GetInto(ctx, "shutdown", &output)
 
 	return output, size, err
 }
@@ -107,8 +179,14 @@ func (n *NZBGet) Shutdown() (bool, int, error) {
 // Reload makes NZBGet stop all activities and reinitialize.
 // https://nzbget.net/api/reload
 func (n *NZBGet) Reload() (bool, int, error) {
+	return n.ReloadWithContext(context.Background())
+}
+
+// ReloadWithContext makes NZBGet stop all activities and reinitialize.
+// https://nzbget.net/api/reload
+func (n *NZBGet) ReloadWithContext(ctx context.Context) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("reload", &output)
+	size, err := n.GetInto(ctx, "reload", &output)
 
 	return output, size, err
 }
@@ -116,8 +194,14 @@ func (n *NZBGet) Reload() (bool, int, error) {
 // Rate sets download speed limit.
 // https://nzbget.net/api/rate
 func (n *NZBGet) Rate(limit int64) (bool, int, error) {
+	return n.RateWithContext(context.Background(), limit)
+}
+
+// RateWithContext sets download speed limit.
+// https://nzbget.net/api/rate
+func (n *NZBGet) RateWithContext(ctx context.Context, limit int64) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("rate", &output, limit)
+	size, err := n.GetInto(ctx, "rate", &output, limit)
 
 	return output, size, err
 }
@@ -125,8 +209,14 @@ func (n *NZBGet) Rate(limit int64) (bool, int, error) {
 // PausePost pauses post processing.
 // https://nzbget.net/api/pausepost
 func (n *NZBGet) PausePost() (bool, int, error) {
+	return n.PausePostWithContext(context.Background())
+}
+
+// PausePostWithContext pauses post processing.
+// https://nzbget.net/api/pausepost
+func (n *NZBGet) PausePostWithContext(ctx context.Context) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("pausepost", &output)
+	size, err := n.GetInto(ctx, "pausepost", &output)
 
 	return output, size, err
 }
@@ -134,8 +224,14 @@ func (n *NZBGet) PausePost() (bool, int, error) {
 // ResumePost resumes post processing.
 // https://nzbget.net/api/resumepost
 func (n *NZBGet) ResumePost() (bool, int, error) {
+	return n.ResumePostWithContext(context.Background())
+}
+
+// ResumePostWithContext resumes post processing.
+// https://nzbget.net/api/resumepost
+func (n *NZBGet) ResumePostWithContext(ctx context.Context) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("resumepost", &output)
+	size, err := n.GetInto(ctx, "resumepost", &output)
 
 	return output, size, err
 }
@@ -143,8 +239,14 @@ func (n *NZBGet) ResumePost() (bool, int, error) {
 // PauseDownload pauses downloads.
 // https://nzbget.net/api/pausedownload
 func (n *NZBGet) PauseDownload() (bool, int, error) {
+	return n.PauseDownloadWithContext(context.Background())
+}
+
+// PauseDownloadWithContext pauses downloads.
+// https://nzbget.net/api/pausedownload
+func (n *NZBGet) PauseDownloadWithContext(ctx context.Context) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("pausedownload", &output)
+	size, err := n.GetInto(ctx, "pausedownload", &output)
 
 	return output, size, err
 }
@@ -152,8 +254,14 @@ func (n *NZBGet) PauseDownload() (bool, int, error) {
 // ResumeDownload resumes downloads.
 // https://nzbget.net/api/resumedownload
 func (n *NZBGet) ResumeDownload() (bool, int, error) {
+	return n.ResumeDownloadWithContext(context.Background())
+}
+
+// ResumeDownloadWithContext resumes downloads.
+// https://nzbget.net/api/resumedownload
+func (n *NZBGet) ResumeDownloadWithContext(ctx context.Context) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("resumedownload", &output)
+	size, err := n.GetInto(ctx, "resumedownload", &output)
 
 	return output, size, err
 }
@@ -161,8 +269,14 @@ func (n *NZBGet) ResumeDownload() (bool, int, error) {
 // PauseScan pauses scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/pausescan
 func (n *NZBGet) PauseScan() (bool, int, error) {
+	return n.PauseScanWithContext(context.Background())
+}
+
+// PauseScanWithContext pauses scanning of directory with incoming nzb-files.
+// https://nzbget.net/api/pausescan
+func (n *NZBGet) PauseScanWithContext(ctx context.Context) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("pausescan", &output)
+	size, err := n.GetInto(ctx, "pausescan", &output)
 
 	return output, size, err
 }
@@ -170,8 +284,14 @@ func (n *NZBGet) PauseScan() (bool, int, error) {
 // ResumeScan resumes scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/resumescan
 func (n *NZBGet) ResumeScan() (bool, int, error) {
+	return n.ResumeScanWithContext(context.Background())
+}
+
+// ResumeScanWithContext resumes scanning of directory with incoming nzb-files.
+// https://nzbget.net/api/resumescan
+func (n *NZBGet) ResumeScanWithContext(ctx context.Context) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("resumescan", &output)
+	size, err := n.GetInto(ctx, "resumescan", &output)
 
 	return output, size, err
 }
@@ -180,8 +300,15 @@ func (n *NZBGet) ResumeScan() (bool, int, error) {
 // Wait duration is rounded to nearest second.
 // https://nzbget.net/api/scheduleresume
 func (n *NZBGet) ScheduleResume(wait time.Duration) (bool, int, error) {
+	return n.ScheduleResumeWithContext(context.Background(), wait)
+}
+
+// ScheduleResumeWithContext schedules resuming of all activities after wait duration elapses.
+// Wait duration is rounded to nearest second.
+// https://nzbget.net/api/scheduleresume
+func (n *NZBGet) ScheduleResumeWithContext(ctx context.Context, wait time.Duration) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("scheduleresume", &output, wait.Seconds())
+	size, err := n.GetInto(ctx, "scheduleresume", &output, wait.Seconds())
 
 	return output, size, err
 }
@@ -189,8 +316,14 @@ func (n *NZBGet) ScheduleResume(wait time.Duration) (bool, int, error) {
 // Scan requests rescanning of incoming directory for nzb-files.
 // https://nzbget.net/api/scheduleresume
 func (n *NZBGet) Scan() (bool, int, error) {
+	return n.ScanWithContext(context.Background())
+}
+
+// ScanWithContext requests rescanning of incoming directory for nzb-files.
+// https://nzbget.net/api/scheduleresume
+func (n *NZBGet) ScanWithContext(ctx context.Context) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("scan", &output)
+	size, err := n.GetInto(ctx, "scan", &output)
 
 	return output, size, err
 }
@@ -198,8 +331,14 @@ func (n *NZBGet) Scan() (bool, int, error) {
 // WriteLog appends a log entry to th server's log and on-screen log buffer.
 // https://nzbget.net/api/writelog
 func (n *NZBGet) WriteLog(kind LogKind, text string) (bool, int, error) {
+	return n.WriteLogWithContext(context.Background(), kind, text)
+}
+
+// WriteLogWithContext appends a log entry to th server's log and on-screen log buffer.
+// https://nzbget.net/api/writelog
+func (n *NZBGet) WriteLogWithContext(ctx context.Context, kind LogKind, text string) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("writelog", &output, kind, text)
+	size, err := n.GetInto(ctx, "writelog", &output, kind, text)
 
 	return output, size, err
 }
@@ -210,8 +349,17 @@ func (n *NZBGet) WriteLog(kind LogKind, text string) (bool, int, error) {
 // page or page “Postprocess” in download details dialog.
 // https://nzbget.net/api/configtemplates
 func (n *NZBGet) ConfigTemplates(loadFromDisk bool) ([]*ConfigTemplate, int, error) {
+	return n.ConfigTemplatesWithContext(context.Background(), loadFromDisk)
+}
+
+// ConfigTemplatesWithContext returns NZBGet configuration file template and
+// also extracts configuration sections from all post-processing files.
+// This information is for example used by web-interface to build settings
+// page or page “Postprocess” in download details dialog.
+// https://nzbget.net/api/configtemplates
+func (n *NZBGet) ConfigTemplatesWithContext(ctx context.Context, loadFromDisk bool) ([]*ConfigTemplate, int, error) {
 	var output []*ConfigTemplate
-	size, err := n.GetInto("configtemplates", &output, loadFromDisk)
+	size, err := n.GetInto(ctx, "configtemplates", &output, loadFromDisk)
 
 	return output, size, err
 }
@@ -220,8 +368,15 @@ func (n *NZBGet) ConfigTemplates(loadFromDisk bool) ([]*ConfigTemplate, int, err
 // https://nzbget.net/api/servervolumes
 // NOTE: The first record (serverid=0) are totals for all servers.
 func (n *NZBGet) ServerVolumes() ([]*ServerVolume, int, error) {
+	return n.ServerVolumesWithContext(context.Background())
+}
+
+// ServerVolumesWithContext returns download volume statistics per news-server.
+// https://nzbget.net/api/servervolumes
+// NOTE: The first record (serverid=0) are totals for all servers.
+func (n *NZBGet) ServerVolumesWithContext(ctx context.Context) ([]*ServerVolume, int, error) {
 	var output []*ServerVolume
-	size, err := n.GetInto("servervolumes", &output)
+	size, err := n.GetInto(ctx, "servervolumes", &output)
 
 	return output, size, err
 }
@@ -229,8 +384,14 @@ func (n *NZBGet) ServerVolumes() ([]*ServerVolume, int, error) {
 // ResetServerVolume resets download volume statistics for a specified news-server.
 // https://nzbget.net/api/resetservervolume
 func (n *NZBGet) ResetServerVolume(serverID int64, sounter string) (bool, int, error) {
+	return n.ResetServerVolumeWithContext(context.Background(), serverID, sounter)
+}
+
+// ResetServerVolumeWithContext resets download volume statistics for a specified news-server.
+// https://nzbget.net/api/resetservervolume
+func (n *NZBGet) ResetServerVolumeWithContext(ctx context.Context, serverID int64, sounter string) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("resetservervolume", &output, serverID, sounter)
+	size, err := n.GetInto(ctx, "resetservervolume", &output, serverID, sounter)
 
 	return output, size, err
 }
@@ -253,8 +414,14 @@ type AppendInput struct {
 // Append adds a nzb-file or URL to the download queue.
 // https://nzbget.net/api/append
 func (n *NZBGet) Append(input *AppendInput) (int64, int, error) {
+	return n.AppendWithContext(context.Background(), input)
+}
+
+// AppendWithContext adds a nzb-file or URL to the download queue.
+// https://nzbget.net/api/append
+func (n *NZBGet) AppendWithContext(ctx context.Context, input *AppendInput) (int64, int, error) {
 	var output int64
-	size, err := n.GetInto("append", &output,
+	size, err := n.GetInto(ctx, "append", &output,
 		input.Filename,
 		input.Content,
 		input.Category,
@@ -274,8 +441,15 @@ func (n *NZBGet) Append(input *AppendInput) (int64, int, error) {
 // Read the official docs for how to issue commands, and which commands are available.
 // https://nzbget.net/api/editqueue
 func (n *NZBGet) EditQueue(command, parameter string, ids []int64) (bool, int, error) {
+	return n.EditQueueWithContext(context.Background(), command, parameter, ids)
+}
+
+// EditQueueWithContext edits items in download queue or in history.
+// Read the official docs for how to issue commands, and which commands are available.
+// https://nzbget.net/api/editqueue
+func (n *NZBGet) EditQueueWithContext(ctx context.Context, command, parameter string, ids []int64) (bool, int, error) {
 	var output bool
-	size, err := n.GetInto("editqueue", &output, command, parameter, ids)
+	size, err := n.GetInto(ctx, "editqueue", &output, command, parameter, ids)
 
 	return output, size, err
 }

--- a/methods.go
+++ b/methods.go
@@ -8,12 +8,12 @@ import (
 // Version returns the NZBGet Version.
 // https://nzbget.net/api/version
 func (n *NZBGet) Version() (string, int, error) {
-	return n.VersionWithContext(context.Background())
+	return n.VersionContext(context.Background())
 }
 
-// VersionWithContext returns the NZBGet Version.
+// VersionContext returns the NZBGet Version.
 // https://nzbget.net/api/version
-func (n *NZBGet) VersionWithContext(ctx context.Context) (string, int, error) {
+func (n *NZBGet) VersionContext(ctx context.Context) (string, int, error) {
 	var output string
 	size, err := n.GetInto(ctx, "version", &output)
 
@@ -24,13 +24,13 @@ func (n *NZBGet) VersionWithContext(ctx context.Context) (string, int, error) {
 // https://nzbget.net/api/listfiles
 // nzbID is the NZBID of the group to be returned. Use 0 for all file groups.
 func (n *NZBGet) ListFiles(nzbID int64) (*File, int, error) {
-	return n.ListFilesWithContext(context.Background(), nzbID)
+	return n.ListFilesContext(context.Background(), nzbID)
 }
 
-// ListFilesWithContext returns the NZBGet Files for a download.
+// ListFilesContext returns the NZBGet Files for a download.
 // https://nzbget.net/api/listfiles
 // nzbID is the NZBID of the group to be returned. Use 0 for all file groups.
-func (n *NZBGet) ListFilesWithContext(ctx context.Context, nzbID int64) (*File, int, error) {
+func (n *NZBGet) ListFilesContext(ctx context.Context, nzbID int64) (*File, int, error) {
 	var output File
 	size, err := n.GetInto(ctx, "listfiles", &output, 0, 0, nzbID)
 
@@ -40,12 +40,12 @@ func (n *NZBGet) ListFilesWithContext(ctx context.Context, nzbID int64) (*File, 
 // Status returns the NZBGet Status.
 // https://nzbget.net/api/status
 func (n *NZBGet) Status() (*Status, int, error) {
-	return n.StatusWithContext(context.Background())
+	return n.StatusContext(context.Background())
 }
 
-// StatusWithContext returns the NZBGet Status.
+// StatusContext returns the NZBGet Status.
 // https://nzbget.net/api/status
-func (n *NZBGet) StatusWithContext(ctx context.Context) (*Status, int, error) {
+func (n *NZBGet) StatusContext(ctx context.Context) (*Status, int, error) {
 	var output Status
 	size, err := n.GetInto(ctx, "status", &output)
 
@@ -55,12 +55,12 @@ func (n *NZBGet) StatusWithContext(ctx context.Context) (*Status, int, error) {
 // History returns the NZBGet Download History.
 // https://nzbget.net/api/history
 func (n *NZBGet) History(hidden bool) ([]*History, int, error) {
-	return n.HistoryWithContext(context.Background(), hidden)
+	return n.HistoryContext(context.Background(), hidden)
 }
 
-// HistoryWithContext returns the NZBGet Download History.
+// HistoryContext returns the NZBGet Download History.
 // https://nzbget.net/api/history
-func (n *NZBGet) HistoryWithContext(ctx context.Context, hidden bool) ([]*History, int, error) {
+func (n *NZBGet) HistoryContext(ctx context.Context, hidden bool) ([]*History, int, error) {
 	var output []*History
 	size, err := n.GetInto(ctx, "history", &output, hidden)
 
@@ -70,12 +70,12 @@ func (n *NZBGet) HistoryWithContext(ctx context.Context, hidden bool) ([]*Histor
 // ListGroups returns the NZBGet Download list.
 // https://nzbget.net/api/listgroups
 func (n *NZBGet) ListGroups() ([]*Group, int, error) {
-	return n.ListGroupsWithContext(context.Background())
+	return n.ListGroupsContext(context.Background())
 }
 
-// ListGroupsWithContext returns the NZBGet Download list.
+// ListGroupsContext returns the NZBGet Download list.
 // https://nzbget.net/api/listgroups
-func (n *NZBGet) ListGroupsWithContext(ctx context.Context) ([]*Group, int, error) {
+func (n *NZBGet) ListGroupsContext(ctx context.Context) ([]*Group, int, error) {
 	var output []*Group
 	size, err := n.GetInto(ctx, "listgroups", &output, 0)
 
@@ -86,13 +86,13 @@ func (n *NZBGet) ListGroupsWithContext(ctx context.Context) ([]*Group, int, erro
 // NOTE: only one parameter - either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/log
 func (n *NZBGet) Log(startID, limit int64) ([]*LogEntry, int, error) {
-	return n.LogWithContext(context.Background(), startID, limit)
+	return n.LogContext(context.Background(), startID, limit)
 }
 
-// LogWithContext returns the NZBGet Logs.
+// LogContext returns the NZBGet Logs.
 // NOTE: only one parameter - either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/log
-func (n *NZBGet) LogWithContext(ctx context.Context, startID, limit int64) ([]*LogEntry, int, error) {
+func (n *NZBGet) LogContext(ctx context.Context, startID, limit int64) ([]*LogEntry, int, error) {
 	var output []*LogEntry
 	size, err := n.GetInto(ctx, "log", &output, startID, limit)
 
@@ -103,13 +103,13 @@ func (n *NZBGet) LogWithContext(ctx context.Context, startID, limit int64) ([]*L
 // NOTE: only one of either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/loadlog
 func (n *NZBGet) LoadLog(nzbID, startID, limit int64) ([]*LogEntry, int, error) {
-	return n.LoadLogWithContext(context.Background(), nzbID, startID, limit)
+	return n.LoadLogContext(context.Background(), nzbID, startID, limit)
 }
 
-// LoadLogWithContext returns the NZBGet log for a specific download.
+// LoadLogContext returns the NZBGet log for a specific download.
 // NOTE: only one of either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/loadlog
-func (n *NZBGet) LoadLogWithContext(ctx context.Context, nzbID, startID, limit int64) ([]*LogEntry, int, error) {
+func (n *NZBGet) LoadLogContext(ctx context.Context, nzbID, startID, limit int64) ([]*LogEntry, int, error) {
 	var output []*LogEntry
 	size, err := n.GetInto(ctx, "loadlog", &output, nzbID, startID, limit)
 
@@ -119,12 +119,12 @@ func (n *NZBGet) LoadLogWithContext(ctx context.Context, nzbID, startID, limit i
 // Config returns the loaded and active NZBGet configuration parameters.
 // https://nzbget.net/api/config
 func (n *NZBGet) Config() ([]*Parameter, int, error) {
-	return n.ConfigWithContext(context.Background())
+	return n.ConfigContext(context.Background())
 }
 
-// ConfigWithContext returns the loaded and active NZBGet configuration parameters.
+// ConfigContext returns the loaded and active NZBGet configuration parameters.
 // https://nzbget.net/api/config
-func (n *NZBGet) ConfigWithContext(ctx context.Context) ([]*Parameter, int, error) {
+func (n *NZBGet) ConfigContext(ctx context.Context) ([]*Parameter, int, error) {
 	var output []*Parameter
 	size, err := n.GetInto(ctx, "config", &output)
 
@@ -134,12 +134,12 @@ func (n *NZBGet) ConfigWithContext(ctx context.Context) ([]*Parameter, int, erro
 // LoadConfig returns the configuration from disk.
 // https://nzbget.net/api/loadconfig
 func (n *NZBGet) LoadConfig() ([]*Parameter, int, error) {
-	return n.LoadConfigWithContext(context.Background())
+	return n.LoadConfigContext(context.Background())
 }
 
-// LoadConfigWithContext returns the configuration from disk.
+// LoadConfigContext returns the configuration from disk.
 // https://nzbget.net/api/loadconfig
-func (n *NZBGet) LoadConfigWithContext(ctx context.Context) ([]*Parameter, int, error) {
+func (n *NZBGet) LoadConfigContext(ctx context.Context) ([]*Parameter, int, error) {
 	var output []*Parameter
 	size, err := n.GetInto(ctx, "loadconfig", &output)
 
@@ -149,12 +149,12 @@ func (n *NZBGet) LoadConfigWithContext(ctx context.Context) ([]*Parameter, int, 
 // SaveConfig writes new configuration parameters to disk.
 // https://nzbget.net/api/saveconfig
 func (n *NZBGet) SaveConfig(configs []*Parameter) (bool, int, error) {
-	return n.SaveConfigWithContext(context.Background(), configs)
+	return n.SaveConfigContext(context.Background(), configs)
 }
 
-// SaveConfigWithContext writes new configuration parameters to disk.
+// SaveConfigContext writes new configuration parameters to disk.
 // https://nzbget.net/api/saveconfig
-func (n *NZBGet) SaveConfigWithContext(ctx context.Context, configs []*Parameter) (bool, int, error) {
+func (n *NZBGet) SaveConfigContext(ctx context.Context, configs []*Parameter) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "saveconfig", &output, configs)
 
@@ -164,12 +164,12 @@ func (n *NZBGet) SaveConfigWithContext(ctx context.Context, configs []*Parameter
 // Shutdown makes NZBGet exit.
 // https://nzbget.net/api/shutdown
 func (n *NZBGet) Shutdown() (bool, int, error) {
-	return n.ShutdownWithContext(context.Background())
+	return n.ShutdownContext(context.Background())
 }
 
-// ShutdownWithContext makes NZBGet exit.
+// ShutdownContext makes NZBGet exit.
 // https://nzbget.net/api/shutdown
-func (n *NZBGet) ShutdownWithContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ShutdownContext(ctx context.Context) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "shutdown", &output)
 
@@ -179,12 +179,12 @@ func (n *NZBGet) ShutdownWithContext(ctx context.Context) (bool, int, error) {
 // Reload makes NZBGet stop all activities and reinitialize.
 // https://nzbget.net/api/reload
 func (n *NZBGet) Reload() (bool, int, error) {
-	return n.ReloadWithContext(context.Background())
+	return n.ReloadContext(context.Background())
 }
 
-// ReloadWithContext makes NZBGet stop all activities and reinitialize.
+// ReloadContext makes NZBGet stop all activities and reinitialize.
 // https://nzbget.net/api/reload
-func (n *NZBGet) ReloadWithContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ReloadContext(ctx context.Context) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "reload", &output)
 
@@ -194,12 +194,12 @@ func (n *NZBGet) ReloadWithContext(ctx context.Context) (bool, int, error) {
 // Rate sets download speed limit.
 // https://nzbget.net/api/rate
 func (n *NZBGet) Rate(limit int64) (bool, int, error) {
-	return n.RateWithContext(context.Background(), limit)
+	return n.RateContext(context.Background(), limit)
 }
 
-// RateWithContext sets download speed limit.
+// RateContext sets download speed limit.
 // https://nzbget.net/api/rate
-func (n *NZBGet) RateWithContext(ctx context.Context, limit int64) (bool, int, error) {
+func (n *NZBGet) RateContext(ctx context.Context, limit int64) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "rate", &output, limit)
 
@@ -209,12 +209,12 @@ func (n *NZBGet) RateWithContext(ctx context.Context, limit int64) (bool, int, e
 // PausePost pauses post processing.
 // https://nzbget.net/api/pausepost
 func (n *NZBGet) PausePost() (bool, int, error) {
-	return n.PausePostWithContext(context.Background())
+	return n.PausePostContext(context.Background())
 }
 
-// PausePostWithContext pauses post processing.
+// PausePostContext pauses post processing.
 // https://nzbget.net/api/pausepost
-func (n *NZBGet) PausePostWithContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) PausePostContext(ctx context.Context) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "pausepost", &output)
 
@@ -224,12 +224,12 @@ func (n *NZBGet) PausePostWithContext(ctx context.Context) (bool, int, error) {
 // ResumePost resumes post processing.
 // https://nzbget.net/api/resumepost
 func (n *NZBGet) ResumePost() (bool, int, error) {
-	return n.ResumePostWithContext(context.Background())
+	return n.ResumePostContext(context.Background())
 }
 
-// ResumePostWithContext resumes post processing.
+// ResumePostContext resumes post processing.
 // https://nzbget.net/api/resumepost
-func (n *NZBGet) ResumePostWithContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ResumePostContext(ctx context.Context) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "resumepost", &output)
 
@@ -239,12 +239,12 @@ func (n *NZBGet) ResumePostWithContext(ctx context.Context) (bool, int, error) {
 // PauseDownload pauses downloads.
 // https://nzbget.net/api/pausedownload
 func (n *NZBGet) PauseDownload() (bool, int, error) {
-	return n.PauseDownloadWithContext(context.Background())
+	return n.PauseDownloadContext(context.Background())
 }
 
-// PauseDownloadWithContext pauses downloads.
+// PauseDownloadContext pauses downloads.
 // https://nzbget.net/api/pausedownload
-func (n *NZBGet) PauseDownloadWithContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) PauseDownloadContext(ctx context.Context) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "pausedownload", &output)
 
@@ -254,12 +254,12 @@ func (n *NZBGet) PauseDownloadWithContext(ctx context.Context) (bool, int, error
 // ResumeDownload resumes downloads.
 // https://nzbget.net/api/resumedownload
 func (n *NZBGet) ResumeDownload() (bool, int, error) {
-	return n.ResumeDownloadWithContext(context.Background())
+	return n.ResumeDownloadContext(context.Background())
 }
 
-// ResumeDownloadWithContext resumes downloads.
+// ResumeDownloadContext resumes downloads.
 // https://nzbget.net/api/resumedownload
-func (n *NZBGet) ResumeDownloadWithContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ResumeDownloadContext(ctx context.Context) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "resumedownload", &output)
 
@@ -269,12 +269,12 @@ func (n *NZBGet) ResumeDownloadWithContext(ctx context.Context) (bool, int, erro
 // PauseScan pauses scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/pausescan
 func (n *NZBGet) PauseScan() (bool, int, error) {
-	return n.PauseScanWithContext(context.Background())
+	return n.PauseScanContext(context.Background())
 }
 
-// PauseScanWithContext pauses scanning of directory with incoming nzb-files.
+// PauseScanContext pauses scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/pausescan
-func (n *NZBGet) PauseScanWithContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) PauseScanContext(ctx context.Context) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "pausescan", &output)
 
@@ -284,12 +284,12 @@ func (n *NZBGet) PauseScanWithContext(ctx context.Context) (bool, int, error) {
 // ResumeScan resumes scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/resumescan
 func (n *NZBGet) ResumeScan() (bool, int, error) {
-	return n.ResumeScanWithContext(context.Background())
+	return n.ResumeScanContext(context.Background())
 }
 
-// ResumeScanWithContext resumes scanning of directory with incoming nzb-files.
+// ResumeScanContext resumes scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/resumescan
-func (n *NZBGet) ResumeScanWithContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ResumeScanContext(ctx context.Context) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "resumescan", &output)
 
@@ -300,13 +300,13 @@ func (n *NZBGet) ResumeScanWithContext(ctx context.Context) (bool, int, error) {
 // Wait duration is rounded to nearest second.
 // https://nzbget.net/api/scheduleresume
 func (n *NZBGet) ScheduleResume(wait time.Duration) (bool, int, error) {
-	return n.ScheduleResumeWithContext(context.Background(), wait)
+	return n.ScheduleResumeContext(context.Background(), wait)
 }
 
-// ScheduleResumeWithContext schedules resuming of all activities after wait duration elapses.
+// ScheduleResumeContext schedules resuming of all activities after wait duration elapses.
 // Wait duration is rounded to nearest second.
 // https://nzbget.net/api/scheduleresume
-func (n *NZBGet) ScheduleResumeWithContext(ctx context.Context, wait time.Duration) (bool, int, error) {
+func (n *NZBGet) ScheduleResumeContext(ctx context.Context, wait time.Duration) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "scheduleresume", &output, wait.Seconds())
 
@@ -316,12 +316,12 @@ func (n *NZBGet) ScheduleResumeWithContext(ctx context.Context, wait time.Durati
 // Scan requests rescanning of incoming directory for nzb-files.
 // https://nzbget.net/api/scheduleresume
 func (n *NZBGet) Scan() (bool, int, error) {
-	return n.ScanWithContext(context.Background())
+	return n.ScanContext(context.Background())
 }
 
-// ScanWithContext requests rescanning of incoming directory for nzb-files.
+// ScanContext requests rescanning of incoming directory for nzb-files.
 // https://nzbget.net/api/scheduleresume
-func (n *NZBGet) ScanWithContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ScanContext(ctx context.Context) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "scan", &output)
 
@@ -331,12 +331,12 @@ func (n *NZBGet) ScanWithContext(ctx context.Context) (bool, int, error) {
 // WriteLog appends a log entry to th server's log and on-screen log buffer.
 // https://nzbget.net/api/writelog
 func (n *NZBGet) WriteLog(kind LogKind, text string) (bool, int, error) {
-	return n.WriteLogWithContext(context.Background(), kind, text)
+	return n.WriteLogContext(context.Background(), kind, text)
 }
 
-// WriteLogWithContext appends a log entry to th server's log and on-screen log buffer.
+// WriteLogContext appends a log entry to th server's log and on-screen log buffer.
 // https://nzbget.net/api/writelog
-func (n *NZBGet) WriteLogWithContext(ctx context.Context, kind LogKind, text string) (bool, int, error) {
+func (n *NZBGet) WriteLogContext(ctx context.Context, kind LogKind, text string) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "writelog", &output, kind, text)
 
@@ -349,15 +349,15 @@ func (n *NZBGet) WriteLogWithContext(ctx context.Context, kind LogKind, text str
 // page or page “Postprocess” in download details dialog.
 // https://nzbget.net/api/configtemplates
 func (n *NZBGet) ConfigTemplates(loadFromDisk bool) ([]*ConfigTemplate, int, error) {
-	return n.ConfigTemplatesWithContext(context.Background(), loadFromDisk)
+	return n.ConfigTemplatesContext(context.Background(), loadFromDisk)
 }
 
-// ConfigTemplatesWithContext returns NZBGet configuration file template and
+// ConfigTemplatesContext returns NZBGet configuration file template and
 // also extracts configuration sections from all post-processing files.
 // This information is for example used by web-interface to build settings
 // page or page “Postprocess” in download details dialog.
 // https://nzbget.net/api/configtemplates
-func (n *NZBGet) ConfigTemplatesWithContext(ctx context.Context, loadFromDisk bool) ([]*ConfigTemplate, int, error) {
+func (n *NZBGet) ConfigTemplatesContext(ctx context.Context, loadFromDisk bool) ([]*ConfigTemplate, int, error) {
 	var output []*ConfigTemplate
 	size, err := n.GetInto(ctx, "configtemplates", &output, loadFromDisk)
 
@@ -368,13 +368,13 @@ func (n *NZBGet) ConfigTemplatesWithContext(ctx context.Context, loadFromDisk bo
 // https://nzbget.net/api/servervolumes
 // NOTE: The first record (serverid=0) are totals for all servers.
 func (n *NZBGet) ServerVolumes() ([]*ServerVolume, int, error) {
-	return n.ServerVolumesWithContext(context.Background())
+	return n.ServerVolumesContext(context.Background())
 }
 
-// ServerVolumesWithContext returns download volume statistics per news-server.
+// ServerVolumesContext returns download volume statistics per news-server.
 // https://nzbget.net/api/servervolumes
 // NOTE: The first record (serverid=0) are totals for all servers.
-func (n *NZBGet) ServerVolumesWithContext(ctx context.Context) ([]*ServerVolume, int, error) {
+func (n *NZBGet) ServerVolumesContext(ctx context.Context) ([]*ServerVolume, int, error) {
 	var output []*ServerVolume
 	size, err := n.GetInto(ctx, "servervolumes", &output)
 
@@ -384,12 +384,12 @@ func (n *NZBGet) ServerVolumesWithContext(ctx context.Context) ([]*ServerVolume,
 // ResetServerVolume resets download volume statistics for a specified news-server.
 // https://nzbget.net/api/resetservervolume
 func (n *NZBGet) ResetServerVolume(serverID int64, sounter string) (bool, int, error) {
-	return n.ResetServerVolumeWithContext(context.Background(), serverID, sounter)
+	return n.ResetServerVolumeContext(context.Background(), serverID, sounter)
 }
 
-// ResetServerVolumeWithContext resets download volume statistics for a specified news-server.
+// ResetServerVolumeContext resets download volume statistics for a specified news-server.
 // https://nzbget.net/api/resetservervolume
-func (n *NZBGet) ResetServerVolumeWithContext(ctx context.Context, serverID int64, sounter string) (bool, int, error) {
+func (n *NZBGet) ResetServerVolumeContext(ctx context.Context, serverID int64, sounter string) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "resetservervolume", &output, serverID, sounter)
 
@@ -414,12 +414,12 @@ type AppendInput struct {
 // Append adds a nzb-file or URL to the download queue.
 // https://nzbget.net/api/append
 func (n *NZBGet) Append(input *AppendInput) (int64, int, error) {
-	return n.AppendWithContext(context.Background(), input)
+	return n.AppendContext(context.Background(), input)
 }
 
-// AppendWithContext adds a nzb-file or URL to the download queue.
+// AppendContext adds a nzb-file or URL to the download queue.
 // https://nzbget.net/api/append
-func (n *NZBGet) AppendWithContext(ctx context.Context, input *AppendInput) (int64, int, error) {
+func (n *NZBGet) AppendContext(ctx context.Context, input *AppendInput) (int64, int, error) {
 	var output int64
 	size, err := n.GetInto(ctx, "append", &output,
 		input.Filename,
@@ -441,13 +441,13 @@ func (n *NZBGet) AppendWithContext(ctx context.Context, input *AppendInput) (int
 // Read the official docs for how to issue commands, and which commands are available.
 // https://nzbget.net/api/editqueue
 func (n *NZBGet) EditQueue(command, parameter string, ids []int64) (bool, int, error) {
-	return n.EditQueueWithContext(context.Background(), command, parameter, ids)
+	return n.EditQueueContext(context.Background(), command, parameter, ids)
 }
 
-// EditQueueWithContext edits items in download queue or in history.
+// EditQueueContext edits items in download queue or in history.
 // Read the official docs for how to issue commands, and which commands are available.
 // https://nzbget.net/api/editqueue
-func (n *NZBGet) EditQueueWithContext(ctx context.Context, command, parameter string, ids []int64) (bool, int, error) {
+func (n *NZBGet) EditQueueContext(ctx context.Context, command, parameter string, ids []int64) (bool, int, error) {
 	var output bool
 	size, err := n.GetInto(ctx, "editqueue", &output, command, parameter, ids)
 

--- a/methods.go
+++ b/methods.go
@@ -7,340 +7,340 @@ import (
 
 // Version returns the NZBGet Version.
 // https://nzbget.net/api/version
-func (n *NZBGet) Version() (string, int, error) {
+func (n *NZBGet) Version() (string, error) {
 	return n.VersionContext(context.Background())
 }
 
 // VersionContext returns the NZBGet Version.
 // https://nzbget.net/api/version
-func (n *NZBGet) VersionContext(ctx context.Context) (string, int, error) {
+func (n *NZBGet) VersionContext(ctx context.Context) (string, error) {
 	var output string
-	size, err := n.GetInto(ctx, "version", &output)
+	err := n.GetInto(ctx, "version", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // ListFiles returns the NZBGet Files for a download.
 // https://nzbget.net/api/listfiles
 // nzbID is the NZBID of the group to be returned. Use 0 for all file groups.
-func (n *NZBGet) ListFiles(nzbID int64) (*File, int, error) {
+func (n *NZBGet) ListFiles(nzbID int64) (*File, error) {
 	return n.ListFilesContext(context.Background(), nzbID)
 }
 
 // ListFilesContext returns the NZBGet Files for a download.
 // https://nzbget.net/api/listfiles
 // nzbID is the NZBID of the group to be returned. Use 0 for all file groups.
-func (n *NZBGet) ListFilesContext(ctx context.Context, nzbID int64) (*File, int, error) {
+func (n *NZBGet) ListFilesContext(ctx context.Context, nzbID int64) (*File, error) {
 	var output File
-	size, err := n.GetInto(ctx, "listfiles", &output, 0, 0, nzbID)
+	err := n.GetInto(ctx, "listfiles", &output, 0, 0, nzbID)
 
-	return &output, size, err
+	return &output, err
 }
 
 // Status returns the NZBGet Status.
 // https://nzbget.net/api/status
-func (n *NZBGet) Status() (*Status, int, error) {
+func (n *NZBGet) Status() (*Status, error) {
 	return n.StatusContext(context.Background())
 }
 
 // StatusContext returns the NZBGet Status.
 // https://nzbget.net/api/status
-func (n *NZBGet) StatusContext(ctx context.Context) (*Status, int, error) {
+func (n *NZBGet) StatusContext(ctx context.Context) (*Status, error) {
 	var output Status
-	size, err := n.GetInto(ctx, "status", &output)
+	err := n.GetInto(ctx, "status", &output)
 
-	return &output, size, err
+	return &output, err
 }
 
 // History returns the NZBGet Download History.
 // https://nzbget.net/api/history
-func (n *NZBGet) History(hidden bool) ([]*History, int, error) {
+func (n *NZBGet) History(hidden bool) ([]*History, error) {
 	return n.HistoryContext(context.Background(), hidden)
 }
 
 // HistoryContext returns the NZBGet Download History.
 // https://nzbget.net/api/history
-func (n *NZBGet) HistoryContext(ctx context.Context, hidden bool) ([]*History, int, error) {
+func (n *NZBGet) HistoryContext(ctx context.Context, hidden bool) ([]*History, error) {
 	var output []*History
-	size, err := n.GetInto(ctx, "history", &output, hidden)
+	err := n.GetInto(ctx, "history", &output, hidden)
 
-	return output, size, err
+	return output, err
 }
 
 // ListGroups returns the NZBGet Download list.
 // https://nzbget.net/api/listgroups
-func (n *NZBGet) ListGroups() ([]*Group, int, error) {
+func (n *NZBGet) ListGroups() ([]*Group, error) {
 	return n.ListGroupsContext(context.Background())
 }
 
 // ListGroupsContext returns the NZBGet Download list.
 // https://nzbget.net/api/listgroups
-func (n *NZBGet) ListGroupsContext(ctx context.Context) ([]*Group, int, error) {
+func (n *NZBGet) ListGroupsContext(ctx context.Context) ([]*Group, error) {
 	var output []*Group
-	size, err := n.GetInto(ctx, "listgroups", &output, 0)
+	err := n.GetInto(ctx, "listgroups", &output, 0)
 
-	return output, size, err
+	return output, err
 }
 
 // Log returns the NZBGet Logs.
 // NOTE: only one parameter - either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/log
-func (n *NZBGet) Log(startID, limit int64) ([]*LogEntry, int, error) {
+func (n *NZBGet) Log(startID, limit int64) ([]*LogEntry, error) {
 	return n.LogContext(context.Background(), startID, limit)
 }
 
 // LogContext returns the NZBGet Logs.
 // NOTE: only one parameter - either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/log
-func (n *NZBGet) LogContext(ctx context.Context, startID, limit int64) ([]*LogEntry, int, error) {
+func (n *NZBGet) LogContext(ctx context.Context, startID, limit int64) ([]*LogEntry, error) {
 	var output []*LogEntry
-	size, err := n.GetInto(ctx, "log", &output, startID, limit)
+	err := n.GetInto(ctx, "log", &output, startID, limit)
 
-	return output, size, err
+	return output, err
 }
 
 // LoadLog returns the NZBGet log for a specific download.
 // NOTE: only one of either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/loadlog
-func (n *NZBGet) LoadLog(nzbID, startID, limit int64) ([]*LogEntry, int, error) {
+func (n *NZBGet) LoadLog(nzbID, startID, limit int64) ([]*LogEntry, error) {
 	return n.LoadLogContext(context.Background(), nzbID, startID, limit)
 }
 
 // LoadLogContext returns the NZBGet log for a specific download.
 // NOTE: only one of either startID or limit - can be specified. The other parameter must be 0.
 // https://nzbget.net/api/loadlog
-func (n *NZBGet) LoadLogContext(ctx context.Context, nzbID, startID, limit int64) ([]*LogEntry, int, error) {
+func (n *NZBGet) LoadLogContext(ctx context.Context, nzbID, startID, limit int64) ([]*LogEntry, error) {
 	var output []*LogEntry
-	size, err := n.GetInto(ctx, "loadlog", &output, nzbID, startID, limit)
+	err := n.GetInto(ctx, "loadlog", &output, nzbID, startID, limit)
 
-	return output, size, err
+	return output, err
 }
 
 // Config returns the loaded and active NZBGet configuration parameters.
 // https://nzbget.net/api/config
-func (n *NZBGet) Config() ([]*Parameter, int, error) {
+func (n *NZBGet) Config() ([]*Parameter, error) {
 	return n.ConfigContext(context.Background())
 }
 
 // ConfigContext returns the loaded and active NZBGet configuration parameters.
 // https://nzbget.net/api/config
-func (n *NZBGet) ConfigContext(ctx context.Context) ([]*Parameter, int, error) {
+func (n *NZBGet) ConfigContext(ctx context.Context) ([]*Parameter, error) {
 	var output []*Parameter
-	size, err := n.GetInto(ctx, "config", &output)
+	err := n.GetInto(ctx, "config", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // LoadConfig returns the configuration from disk.
 // https://nzbget.net/api/loadconfig
-func (n *NZBGet) LoadConfig() ([]*Parameter, int, error) {
+func (n *NZBGet) LoadConfig() ([]*Parameter, error) {
 	return n.LoadConfigContext(context.Background())
 }
 
 // LoadConfigContext returns the configuration from disk.
 // https://nzbget.net/api/loadconfig
-func (n *NZBGet) LoadConfigContext(ctx context.Context) ([]*Parameter, int, error) {
+func (n *NZBGet) LoadConfigContext(ctx context.Context) ([]*Parameter, error) {
 	var output []*Parameter
-	size, err := n.GetInto(ctx, "loadconfig", &output)
+	err := n.GetInto(ctx, "loadconfig", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // SaveConfig writes new configuration parameters to disk.
 // https://nzbget.net/api/saveconfig
-func (n *NZBGet) SaveConfig(configs []*Parameter) (bool, int, error) {
+func (n *NZBGet) SaveConfig(configs []*Parameter) (bool, error) {
 	return n.SaveConfigContext(context.Background(), configs)
 }
 
 // SaveConfigContext writes new configuration parameters to disk.
 // https://nzbget.net/api/saveconfig
-func (n *NZBGet) SaveConfigContext(ctx context.Context, configs []*Parameter) (bool, int, error) {
+func (n *NZBGet) SaveConfigContext(ctx context.Context, configs []*Parameter) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "saveconfig", &output, configs)
+	err := n.GetInto(ctx, "saveconfig", &output, configs)
 
-	return output, size, err
+	return output, err
 }
 
 // Shutdown makes NZBGet exit.
 // https://nzbget.net/api/shutdown
-func (n *NZBGet) Shutdown() (bool, int, error) {
+func (n *NZBGet) Shutdown() (bool, error) {
 	return n.ShutdownContext(context.Background())
 }
 
 // ShutdownContext makes NZBGet exit.
 // https://nzbget.net/api/shutdown
-func (n *NZBGet) ShutdownContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ShutdownContext(ctx context.Context) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "shutdown", &output)
+	err := n.GetInto(ctx, "shutdown", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // Reload makes NZBGet stop all activities and reinitialize.
 // https://nzbget.net/api/reload
-func (n *NZBGet) Reload() (bool, int, error) {
+func (n *NZBGet) Reload() (bool, error) {
 	return n.ReloadContext(context.Background())
 }
 
 // ReloadContext makes NZBGet stop all activities and reinitialize.
 // https://nzbget.net/api/reload
-func (n *NZBGet) ReloadContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ReloadContext(ctx context.Context) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "reload", &output)
+	err := n.GetInto(ctx, "reload", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // Rate sets download speed limit.
 // https://nzbget.net/api/rate
-func (n *NZBGet) Rate(limit int64) (bool, int, error) {
+func (n *NZBGet) Rate(limit int64) (bool, error) {
 	return n.RateContext(context.Background(), limit)
 }
 
 // RateContext sets download speed limit.
 // https://nzbget.net/api/rate
-func (n *NZBGet) RateContext(ctx context.Context, limit int64) (bool, int, error) {
+func (n *NZBGet) RateContext(ctx context.Context, limit int64) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "rate", &output, limit)
+	err := n.GetInto(ctx, "rate", &output, limit)
 
-	return output, size, err
+	return output, err
 }
 
 // PausePost pauses post processing.
 // https://nzbget.net/api/pausepost
-func (n *NZBGet) PausePost() (bool, int, error) {
+func (n *NZBGet) PausePost() (bool, error) {
 	return n.PausePostContext(context.Background())
 }
 
 // PausePostContext pauses post processing.
 // https://nzbget.net/api/pausepost
-func (n *NZBGet) PausePostContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) PausePostContext(ctx context.Context) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "pausepost", &output)
+	err := n.GetInto(ctx, "pausepost", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // ResumePost resumes post processing.
 // https://nzbget.net/api/resumepost
-func (n *NZBGet) ResumePost() (bool, int, error) {
+func (n *NZBGet) ResumePost() (bool, error) {
 	return n.ResumePostContext(context.Background())
 }
 
 // ResumePostContext resumes post processing.
 // https://nzbget.net/api/resumepost
-func (n *NZBGet) ResumePostContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ResumePostContext(ctx context.Context) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "resumepost", &output)
+	err := n.GetInto(ctx, "resumepost", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // PauseDownload pauses downloads.
 // https://nzbget.net/api/pausedownload
-func (n *NZBGet) PauseDownload() (bool, int, error) {
+func (n *NZBGet) PauseDownload() (bool, error) {
 	return n.PauseDownloadContext(context.Background())
 }
 
 // PauseDownloadContext pauses downloads.
 // https://nzbget.net/api/pausedownload
-func (n *NZBGet) PauseDownloadContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) PauseDownloadContext(ctx context.Context) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "pausedownload", &output)
+	err := n.GetInto(ctx, "pausedownload", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // ResumeDownload resumes downloads.
 // https://nzbget.net/api/resumedownload
-func (n *NZBGet) ResumeDownload() (bool, int, error) {
+func (n *NZBGet) ResumeDownload() (bool, error) {
 	return n.ResumeDownloadContext(context.Background())
 }
 
 // ResumeDownloadContext resumes downloads.
 // https://nzbget.net/api/resumedownload
-func (n *NZBGet) ResumeDownloadContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ResumeDownloadContext(ctx context.Context) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "resumedownload", &output)
+	err := n.GetInto(ctx, "resumedownload", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // PauseScan pauses scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/pausescan
-func (n *NZBGet) PauseScan() (bool, int, error) {
+func (n *NZBGet) PauseScan() (bool, error) {
 	return n.PauseScanContext(context.Background())
 }
 
 // PauseScanContext pauses scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/pausescan
-func (n *NZBGet) PauseScanContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) PauseScanContext(ctx context.Context) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "pausescan", &output)
+	err := n.GetInto(ctx, "pausescan", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // ResumeScan resumes scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/resumescan
-func (n *NZBGet) ResumeScan() (bool, int, error) {
+func (n *NZBGet) ResumeScan() (bool, error) {
 	return n.ResumeScanContext(context.Background())
 }
 
 // ResumeScanContext resumes scanning of directory with incoming nzb-files.
 // https://nzbget.net/api/resumescan
-func (n *NZBGet) ResumeScanContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ResumeScanContext(ctx context.Context) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "resumescan", &output)
+	err := n.GetInto(ctx, "resumescan", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // ScheduleResume schedules resuming of all activities after wait duration elapses.
 // Wait duration is rounded to nearest second.
 // https://nzbget.net/api/scheduleresume
-func (n *NZBGet) ScheduleResume(wait time.Duration) (bool, int, error) {
+func (n *NZBGet) ScheduleResume(wait time.Duration) (bool, error) {
 	return n.ScheduleResumeContext(context.Background(), wait)
 }
 
 // ScheduleResumeContext schedules resuming of all activities after wait duration elapses.
 // Wait duration is rounded to nearest second.
 // https://nzbget.net/api/scheduleresume
-func (n *NZBGet) ScheduleResumeContext(ctx context.Context, wait time.Duration) (bool, int, error) {
+func (n *NZBGet) ScheduleResumeContext(ctx context.Context, wait time.Duration) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "scheduleresume", &output, wait.Seconds())
+	err := n.GetInto(ctx, "scheduleresume", &output, wait.Seconds())
 
-	return output, size, err
+	return output, err
 }
 
 // Scan requests rescanning of incoming directory for nzb-files.
 // https://nzbget.net/api/scheduleresume
-func (n *NZBGet) Scan() (bool, int, error) {
+func (n *NZBGet) Scan() (bool, error) {
 	return n.ScanContext(context.Background())
 }
 
 // ScanContext requests rescanning of incoming directory for nzb-files.
 // https://nzbget.net/api/scheduleresume
-func (n *NZBGet) ScanContext(ctx context.Context) (bool, int, error) {
+func (n *NZBGet) ScanContext(ctx context.Context) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "scan", &output)
+	err := n.GetInto(ctx, "scan", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // WriteLog appends a log entry to th server's log and on-screen log buffer.
 // https://nzbget.net/api/writelog
-func (n *NZBGet) WriteLog(kind LogKind, text string) (bool, int, error) {
+func (n *NZBGet) WriteLog(kind LogKind, text string) (bool, error) {
 	return n.WriteLogContext(context.Background(), kind, text)
 }
 
 // WriteLogContext appends a log entry to th server's log and on-screen log buffer.
 // https://nzbget.net/api/writelog
-func (n *NZBGet) WriteLogContext(ctx context.Context, kind LogKind, text string) (bool, int, error) {
+func (n *NZBGet) WriteLogContext(ctx context.Context, kind LogKind, text string) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "writelog", &output, kind, text)
+	err := n.GetInto(ctx, "writelog", &output, kind, text)
 
-	return output, size, err
+	return output, err
 }
 
 // ConfigTemplates returns NZBGet configuration file template and
@@ -348,7 +348,7 @@ func (n *NZBGet) WriteLogContext(ctx context.Context, kind LogKind, text string)
 // This information is for example used by web-interface to build settings
 // page or page “Postprocess” in download details dialog.
 // https://nzbget.net/api/configtemplates
-func (n *NZBGet) ConfigTemplates(loadFromDisk bool) ([]*ConfigTemplate, int, error) {
+func (n *NZBGet) ConfigTemplates(loadFromDisk bool) ([]*ConfigTemplate, error) {
 	return n.ConfigTemplatesContext(context.Background(), loadFromDisk)
 }
 
@@ -357,43 +357,43 @@ func (n *NZBGet) ConfigTemplates(loadFromDisk bool) ([]*ConfigTemplate, int, err
 // This information is for example used by web-interface to build settings
 // page or page “Postprocess” in download details dialog.
 // https://nzbget.net/api/configtemplates
-func (n *NZBGet) ConfigTemplatesContext(ctx context.Context, loadFromDisk bool) ([]*ConfigTemplate, int, error) {
+func (n *NZBGet) ConfigTemplatesContext(ctx context.Context, loadFromDisk bool) ([]*ConfigTemplate, error) {
 	var output []*ConfigTemplate
-	size, err := n.GetInto(ctx, "configtemplates", &output, loadFromDisk)
+	err := n.GetInto(ctx, "configtemplates", &output, loadFromDisk)
 
-	return output, size, err
+	return output, err
 }
 
 // ServerVolumes returns download volume statistics per news-server.
 // https://nzbget.net/api/servervolumes
 // NOTE: The first record (serverid=0) are totals for all servers.
-func (n *NZBGet) ServerVolumes() ([]*ServerVolume, int, error) {
+func (n *NZBGet) ServerVolumes() ([]*ServerVolume, error) {
 	return n.ServerVolumesContext(context.Background())
 }
 
 // ServerVolumesContext returns download volume statistics per news-server.
 // https://nzbget.net/api/servervolumes
 // NOTE: The first record (serverid=0) are totals for all servers.
-func (n *NZBGet) ServerVolumesContext(ctx context.Context) ([]*ServerVolume, int, error) {
+func (n *NZBGet) ServerVolumesContext(ctx context.Context) ([]*ServerVolume, error) {
 	var output []*ServerVolume
-	size, err := n.GetInto(ctx, "servervolumes", &output)
+	err := n.GetInto(ctx, "servervolumes", &output)
 
-	return output, size, err
+	return output, err
 }
 
 // ResetServerVolume resets download volume statistics for a specified news-server.
 // https://nzbget.net/api/resetservervolume
-func (n *NZBGet) ResetServerVolume(serverID int64, sounter string) (bool, int, error) {
+func (n *NZBGet) ResetServerVolume(serverID int64, sounter string) (bool, error) {
 	return n.ResetServerVolumeContext(context.Background(), serverID, sounter)
 }
 
 // ResetServerVolumeContext resets download volume statistics for a specified news-server.
 // https://nzbget.net/api/resetservervolume
-func (n *NZBGet) ResetServerVolumeContext(ctx context.Context, serverID int64, sounter string) (bool, int, error) {
+func (n *NZBGet) ResetServerVolumeContext(ctx context.Context, serverID int64, sounter string) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "resetservervolume", &output, serverID, sounter)
+	err := n.GetInto(ctx, "resetservervolume", &output, serverID, sounter)
 
-	return output, size, err
+	return output, err
 }
 
 // AppendInput is the input data for the append method.
@@ -413,15 +413,15 @@ type AppendInput struct {
 
 // Append adds a nzb-file or URL to the download queue.
 // https://nzbget.net/api/append
-func (n *NZBGet) Append(input *AppendInput) (int64, int, error) {
+func (n *NZBGet) Append(input *AppendInput) (int64, error) {
 	return n.AppendContext(context.Background(), input)
 }
 
 // AppendContext adds a nzb-file or URL to the download queue.
 // https://nzbget.net/api/append
-func (n *NZBGet) AppendContext(ctx context.Context, input *AppendInput) (int64, int, error) {
+func (n *NZBGet) AppendContext(ctx context.Context, input *AppendInput) (int64, error) {
 	var output int64
-	size, err := n.GetInto(ctx, "append", &output,
+	err := n.GetInto(ctx, "append", &output,
 		input.Filename,
 		input.Content,
 		input.Category,
@@ -434,22 +434,22 @@ func (n *NZBGet) AppendContext(ctx context.Context, input *AppendInput) (int64, 
 		input.Parameters,
 	)
 
-	return output, size, err
+	return output, err
 }
 
 // EditQueue edits items in download queue or in history.
 // Read the official docs for how to issue commands, and which commands are available.
 // https://nzbget.net/api/editqueue
-func (n *NZBGet) EditQueue(command, parameter string, ids []int64) (bool, int, error) {
+func (n *NZBGet) EditQueue(command, parameter string, ids []int64) (bool, error) {
 	return n.EditQueueContext(context.Background(), command, parameter, ids)
 }
 
 // EditQueueContext edits items in download queue or in history.
 // Read the official docs for how to issue commands, and which commands are available.
 // https://nzbget.net/api/editqueue
-func (n *NZBGet) EditQueueContext(ctx context.Context, command, parameter string, ids []int64) (bool, int, error) {
+func (n *NZBGet) EditQueueContext(ctx context.Context, command, parameter string, ids []int64) (bool, error) {
 	var output bool
-	size, err := n.GetInto(ctx, "editqueue", &output, command, parameter, ids)
+	err := n.GetInto(ctx, "editqueue", &output, command, parameter, ids)
 
-	return output, size, err
+	return output, err
 }

--- a/nzbget.go
+++ b/nzbget.go
@@ -2,6 +2,7 @@ package nzbget
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
@@ -85,13 +86,13 @@ func New(config *Config) *NZBGet {
 }
 
 // GetInto is a helper method to make a JSON-RPC request and turn the response into structured data.
-func (n *NZBGet) GetInto(method string, output interface{}, args ...interface{}) (int, error) {
+func (n *NZBGet) GetInto(ctx context.Context, method string, output interface{}, args ...interface{}) (int, error) {
 	message, err := json.EncodeClientRequest(method, args)
 	if err != nil {
 		return 0, fmt.Errorf("encoding request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", n.url, bytes.NewBuffer(message))
+	req, err := http.NewRequestWithContext(ctx, "POST", n.url, bytes.NewBuffer(message))
 	if err != nil {
 		return 0, fmt.Errorf("creating request: %w", err)
 	}

--- a/nzbget.go
+++ b/nzbget.go
@@ -3,10 +3,8 @@ package nzbget
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -19,19 +17,13 @@ const (
 	DefaultTimeout = 1 * time.Minute
 )
 
-// maxBodyError limits the size of the body that gets appended to an error.
-// ie. if a bad URL is used, the body content that shows the error gets appended to the error.
-// sometimes the body cotent is huge, so we limit it to 1000 charaters.
-const maxBodyError = 1000
-
 // Config is the input data needed to return a NZBGet struct.
 // This is setup to allow you to easily pass this data in from a config file.
 type Config struct {
-	URL       string   `json:"url" toml:"url" xml:"url" yaml:"url"`
-	User      string   `json:"user" toml:"user" xml:"user" yaml:"user"`
-	Pass      string   `json:"pass" toml:"pass" xml:"pass" yaml:"pass"`
-	Timeout   Duration `json:"timeout" toml:"timeout" xml:"timeout" yaml:"timeout"`
-	VerifySSL bool     `json:"verify_ssl" toml:"verify_ssl" xml:"verify_ssl" yaml:"verify_ssl"`
+	URL    string       `json:"url" toml:"url" xml:"url" yaml:"url"`
+	User   string       `json:"user" toml:"user" xml:"user" yaml:"user"`
+	Pass   string       `json:"pass" toml:"pass" xml:"pass" yaml:"pass"`
+	Client *http.Client `json:"-" toml:"-" xml:"-" yaml:"-"` // optional.
 }
 
 // NZBGet is what you get in return for passing in a valid Config to New().
@@ -40,27 +32,12 @@ type NZBGet struct {
 	url    string
 }
 
-// Duration is used to parse durations from a config file.
-type Duration struct{ time.Duration }
-
 type client struct {
-	auth string
+	Auth string
 	*http.Client
 }
 
-// UnmarshalText parses a duration type from a config file.
-func (d *Duration) UnmarshalText(data []byte) error {
-	var err error
-	d.Duration, err = time.ParseDuration(string(data))
-	return err // nolint:wrapcheck,wsl
-}
-
 func New(config *Config) *NZBGet {
-	timeout := config.Timeout.Duration
-	if timeout == 0 {
-		timeout = DefaultTimeout
-	}
-
 	// Set username and password if one's configured.
 	auth := config.User + ":" + config.Pass
 	if auth != ":" {
@@ -69,73 +46,48 @@ func New(config *Config) *NZBGet {
 		auth = ""
 	}
 
-	nzb := &NZBGet{
-		url: strings.TrimSuffix(config.URL, "/jsonrpc") + "/jsonrpc",
-		client: &client{
-			auth: auth,
-			Client: &http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: config.VerifySSL}, //nolint:gosec
-				},
-				Timeout: timeout,
-			},
-		},
+	httpClient := config.Client
+	if httpClient == nil {
+		httpClient = &http.Client{}
 	}
 
-	return nzb
+	return &NZBGet{
+		url: strings.TrimSuffix(config.URL, "/jsonrpc") + "/jsonrpc",
+		client: &client{
+			Auth:   auth,
+			Client: httpClient,
+		},
+	}
 }
 
 // GetInto is a helper method to make a JSON-RPC request and turn the response into structured data.
-func (n *NZBGet) GetInto(ctx context.Context, method string, output interface{}, args ...interface{}) (int, error) {
+func (n *NZBGet) GetInto(ctx context.Context, method string, output interface{}, args ...interface{}) error {
 	message, err := json.EncodeClientRequest(method, args)
 	if err != nil {
-		return 0, fmt.Errorf("encoding request: %w", err)
+		return fmt.Errorf("encoding request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", n.url, bytes.NewBuffer(message))
 	if err != nil {
-		return 0, fmt.Errorf("creating request: %w", err)
+		return fmt.Errorf("creating request: %w", err)
 	}
 
-	resp, err := n.client.Do(req)
-	if err != nil {
-		return 0, fmt.Errorf("making request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	var buf bytes.Buffer
-	defer buf.Reset()
-
-	tee := io.TeeReader(resp.Body, &buf)
-	if err := json.DecodeClientResponse(tee, &output); err != nil {
-		return buf.Len(), fmt.Errorf("parsing response: %w: %s %s", err, resp.Status, limitBuf(&buf))
-	}
-
-	return buf.Len(), nil
-}
-
-// Do allows overriding the http request parameters in aggregate.
-func (c *client) Do(req *http.Request) (*http.Response, error) {
-	if c.auth != "" {
-		req.Header.Set("Authorization", c.auth)
+	if n.client.Auth != "" {
+		req.Header.Set("Authorization", n.client.Auth)
 	}
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.Client.Do(req)
+	resp, err := n.client.Do(req)
 	if err != nil {
-		return resp, fmt.Errorf("making request: %w", err)
+		return fmt.Errorf("making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := json.DecodeClientResponse(resp.Body, &output); err != nil {
+		return fmt.Errorf("parsing response: %w: %s", err, resp.Status)
 	}
 
-	return resp, nil
-}
-
-func limitBuf(buf *bytes.Buffer) string {
-	str := buf.String()
-	if len(str) > maxBodyError {
-		return str[:maxBodyError]
-	}
-
-	return str
+	return nil
 }


### PR DESCRIPTION
This contribution removes the Timeout and VerifySSL inputs, replaces them with an http Client. Also removes the response body size from all returns. You can get this with a custom http Client Transport, so it isn't needed here. Also adds `Context` methods for all the exposed methods.